### PR TITLE
Expanded DataFrame to 3 classes, removed zoneVisits

### DIFF
--- a/Client-PC/src/main/java/uk/ac/cam/cl/wildpetscience/triton/demo/PositionTestPanel.java
+++ b/Client-PC/src/main/java/uk/ac/cam/cl/wildpetscience/triton/demo/PositionTestPanel.java
@@ -12,7 +12,6 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.LinkedList;
 
 /**
  * Lets the user input location data with the mouse.
@@ -53,9 +52,9 @@ public class PositionTestPanel extends JPanel implements MouseMotionListener, Mo
         }
 
         /* Draw the path */
-        List<DataFrame> path = analysis.getPath();
+        List<PositionDataFrame> path = analysis.getPath();
         Point lastPoint = null;
-        for (DataFrame data : path) {
+        for (PositionDataFrame data : path) {
             Point location = data.getLocation();
             int xNew = (int) (location.x * getWidth());
             int yNew = (int) (location.y * getHeight());

--- a/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/models/CageDataFrame.java
+++ b/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/models/CageDataFrame.java
@@ -1,0 +1,31 @@
+package uk.ac.cam.cl.wildpetscience.triton.lib.models;
+
+/**
+ * Encapsulates the cage dimensions data to be sent to the server on config change.
+ */
+public class CageDataFrame {
+
+    private double cageWidth;
+    private double cageHeight;
+
+    public CageDataFrame(double cageWidth, double cageHeight) {
+        this.cageWidth = cageWidth;
+        this.cageHeight = cageHeight;
+    }
+
+    public double getCageWidth() {
+        return cageWidth;
+    }
+
+    public void setCageWidth(double cageWidth) {
+        this.cageWidth = cageWidth;
+    }
+
+    public double getCageHeight() {
+        return cageHeight;
+    }
+
+    public void setCageHeight(double cageHeight) {
+        this.cageHeight = cageHeight;
+    }
+}

--- a/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/models/PositionDataFrame.java
+++ b/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/models/PositionDataFrame.java
@@ -9,27 +9,21 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * Encapsulates the data to be sent to the server.
+ * Encapsulates the position data to be sent to the server regularly.
  */
 
-public class DataFrame {
+public class PositionDataFrame {
 
     private LocalDateTime time;
     private Point location;
     private String zoneId;
     private double speed;
-    private double cageWidth;
-    private double cageHeight;
-    private Map<String, Integer> zoneIdVisits;
 
-    public DataFrame(LocalDateTime time, Point location, String zoneId, double speed, double cageWidth, double cageHeight, Map<String, Integer> zoneIdVisits) {
+    public PositionDataFrame(LocalDateTime time, Point location, String zoneId, double speed) {
         this.time = time;
         this.location = location;
         this.zoneId = zoneId;
         this.speed = speed;
-        this.cageWidth = cageWidth;
-        this.cageHeight = cageHeight;
-        this.zoneIdVisits = zoneIdVisits;
     }
 
     public LocalDateTime getTime() {
@@ -48,28 +42,15 @@ public class DataFrame {
         return speed;
     }
 
-    public double getCageWidth() {
-        return cageWidth;
-    }
-
-    public double getCageHeight() {
-        return cageHeight;
-    }
-
-    public Map<String, Integer> getZoneIdVisits() {
-        return zoneIdVisits;
-    }
-
     public String toString() {
         DecimalFormat df = new DecimalFormat("#0.00");
-        String xString = df.format(location.x*cageWidth);
-        String yString = df.format(location.y*cageHeight);
+        String xString = df.format(location.x);
+        String yString = df.format(location.y);
         String timeString = time.format(DateTimeFormatter.ISO_LOCAL_TIME);
         String out =    "Time:          " + timeString + "\n" +
                         "Location:      " + "("+xString+","+yString+")" + "\n" +
                         "Zone ID:       " + zoneId + "\n" +
-                        "Speed:         " + df.format(speed) + "\n" +
-                        "Cage Size:     " + cageWidth + " x " + cageHeight + "\n";
+                        "Speed:         " + df.format(speed) + "\n";
         return out;
     }
 }

--- a/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/models/ZoneDataFrame.java
+++ b/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/models/ZoneDataFrame.java
@@ -1,0 +1,23 @@
+package uk.ac.cam.cl.wildpetscience.triton.lib.models;
+
+import java.util.Set;
+
+/**
+ * Encapsulates the zone data to be sent to the server on config change.
+ */
+public class ZoneDataFrame {
+
+    private Set<Zone> zones;
+
+    public ZoneDataFrame(Set<Zone> zones) {
+        this.zones = zones;
+    }
+
+    public Set<Zone> getZones() {
+        return zones;
+    }
+
+    public void setZones(Set<Zone> zones) {
+        this.zones = zones;
+    }
+}

--- a/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/pipeline/analysis/Analysis.java
+++ b/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/pipeline/analysis/Analysis.java
@@ -1,11 +1,8 @@
 package uk.ac.cam.cl.wildpetscience.triton.lib.pipeline.analysis;
 
 import uk.ac.cam.cl.wildpetscience.triton.lib.config.ConfigChangedListener;
-import uk.ac.cam.cl.wildpetscience.triton.lib.models.AnimalPosition;
-import uk.ac.cam.cl.wildpetscience.triton.lib.models.ConfigData;
-import uk.ac.cam.cl.wildpetscience.triton.lib.models.DataFrame;
+import uk.ac.cam.cl.wildpetscience.triton.lib.models.*;
 import uk.ac.cam.cl.wildpetscience.triton.lib.pipeline.OutputSink;
-
 import java.util.List;
 
 /**
@@ -13,6 +10,8 @@ import java.util.List;
  */
 public interface Analysis extends OutputSink<AnimalPosition>, ConfigChangedListener {
     public void onConfigChanged(ConfigData configData);
-    public void sendData(DataFrame data);
-    public List<DataFrame> getPath();
+    public void sendPositionData(PositionDataFrame data);
+    public void sendCageData(CageDataFrame data);
+    public void sendZoneData(ZoneDataFrame data);
+    public List<PositionDataFrame> getPath();
 }

--- a/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/pipeline/analysis/AnalysisOutputSink.java
+++ b/Lib/src/main/java/uk/ac/cam/cl/wildpetscience/triton/lib/pipeline/analysis/AnalysisOutputSink.java
@@ -27,29 +27,29 @@ public class AnalysisOutputSink implements OutputSink<AnimalPosition>, Analysis 
     private double cageWidth;
     private double cageHeight;
     private String serverURL;
-    private Map<Zone, Integer> zoneVisits;
+    private Set<Zone> zones;
     private Zone nullZone;
     private AnimalPosition lastKnownPosition;
     private Queue<AnimalPosition> positionQueue;
-    private List<DataFrame> path; // NB: for demo only
+    private List<PositionDataFrame> path; // NB: for demo only
 
     private double threshold = 0.4; // TODO: Experiment with values of threshold
     private int maxDataQueueSize = 5;
-    private Queue<DataFrame> dataQueue = new ArrayQueue<>(maxDataQueueSize);
+    private Queue<PositionDataFrame> dataQueue = new ArrayQueue<>(maxDataQueueSize);
 
     public AnalysisOutputSink (ConfigData config) {
         onConfigChanged(config);
 
         lastKnownPosition = null;
         positionQueue = new LinkedList<AnimalPosition>();
-        path = new LinkedList<DataFrame>();
+        path = new LinkedList<PositionDataFrame>();
     }
 
-    public List<DataFrame> getPath() { return path; } // NB: for demo only
+    public List<PositionDataFrame> getPath() { return path; } // NB: for demo only
 
     /* Finds which zone a point is in. NB: assumes zones are disjoint */
     private Zone pointToZone(Point point) {
-        for (Zone z : zoneVisits.keySet()) {
+        for (Zone z : zones) {
             if (z.area.contains(point)) {
                 return z;
             }
@@ -62,37 +62,24 @@ public class AnalysisOutputSink implements OutputSink<AnimalPosition>, Analysis 
     private double computeSpeed(Point p1, LocalDateTime t1, Point p2, LocalDateTime t2) {
         double xDiff = Math.abs(p1.x - p2.x) * cageWidth;
         double yDiff = Math.abs(p1.y - p2.y) * cageHeight;
-        double displacement = Math.sqrt(xDiff*xDiff + yDiff*yDiff);
+        double displacement = Math.sqrt(xDiff * xDiff + yDiff * yDiff);
         double time = ChronoUnit.MILLIS.between(t1, t2);
         if (time == 0) return 0;
         else return displacement / (time/1000); // time/1000: scale to seconds
     }
 
     /* Makes a DataFrame object for sending to server. NB: utilises lastKnownPosition */
-    public DataFrame makeFrame(AnimalPosition position) {
+    public PositionDataFrame makeFrame(AnimalPosition position) {
         LocalDateTime time = position.getTime();
         Point location = position.getLocation();
         double speed = computeSpeed(lastKnownPosition.getLocation(), lastKnownPosition.getTime(), location, time);
         Zone currentZone = pointToZone(location);
 
-        /* Update visit count for zone */
-        int visits = zoneVisits.get(currentZone);
-        zoneVisits.put(currentZone, visits+1);
-
-        /* Deep copy the id -> visits map */
-        HashMap<String, Integer> zoneIdVisits = new HashMap<String, Integer>(zoneVisits.size());
-        for (Zone z : zoneVisits.keySet()) {
-            zoneIdVisits.put(z.id, zoneVisits.get(z));
-        }
-
-        DataFrame frame = new DataFrame(
+        PositionDataFrame frame = new PositionDataFrame(
                 time,
                 location,
                 currentZone.id,
-                speed,
-                cageWidth,
-                cageHeight,
-                zoneIdVisits
+                speed
         );
 
         return frame;
@@ -104,27 +91,38 @@ public class AnalysisOutputSink implements OutputSink<AnimalPosition>, Analysis 
         this.cageHeight = config.getCageHeight();
         this.serverURL = config.getRemoteServer();
 
-        /* Initialise the zone -> visit map, also acts as a zone set */
-        this.zoneVisits = new HashMap<Zone, Integer>(config.getZones().size()+1);
-        for (Zone z : config.getZones()) {
-            zoneVisits.put(z, 0);
-        }
+        /* Copy the zone set from config, add the null zone */
+        zones = new HashSet<Zone>(config.getZones());
         nullZone = new Zone(new Box(0,0,0,0), "N/A");
-        zoneVisits.put(nullZone,0);
+        zones.add(nullZone);
+
+        /* Send updated data to server */
+        sendCageData(new CageDataFrame(cageWidth, cageHeight));
+        sendZoneData(new ZoneDataFrame(zones));
 
     }
 
     @Override
-    public void sendData(DataFrame data) {
+    public void sendPositionData(PositionDataFrame data) {
         System.out.println(data.toString()); // NB: for demo only
         path.add(data); // NB: for demo only
         dataQueue.add(data);
 
         /* If too much data in queue, flush to server */
         if (dataQueue.size() >= maxDataQueueSize) {
-            // TODO: send to server
-            dataQueue.clear();
+            PositionDataFrame frame = dataQueue.poll();
+            // TODO: [Nick] Interact with API
         }
+    }
+
+    @Override
+    public void sendCageData(CageDataFrame data) {
+        // TODO: [Nick] Interact with API
+    }
+
+    @Override
+    public void sendZoneData(ZoneDataFrame data) {
+        // TODO: [Nick] Interact with API
     }
 
     @Override
@@ -137,7 +135,7 @@ public class AnalysisOutputSink implements OutputSink<AnimalPosition>, Analysis 
         if (lastKnownPosition == null) {
             if (probability > threshold) {
                 lastKnownPosition = image;
-                sendData(makeFrame(image));
+                sendPositionData(makeFrame(image));
             }
             return;
         }
@@ -151,7 +149,7 @@ public class AnalysisOutputSink implements OutputSink<AnimalPosition>, Analysis 
             /* The interpolator also flushes the queue */
             List<AnimalPosition> predictedPoints = (new LinearInterpolator()).predictPoints(lastKnownPosition, image, positionQueue);
             for (AnimalPosition prediction : predictedPoints) {
-                sendData(makeFrame(prediction));
+                sendPositionData(makeFrame(prediction));
                 lastKnownPosition = prediction;
             }
 


### PR DESCRIPTION
DataFrame now expanded to avoid sending cage dimensions and set of
zones unless they have changed.

!!! - This commit also removes client-side zone visit tracking. This
will need to be implemented server-side from now on.
